### PR TITLE
Improve consistency of scrollbar buttons

### DIFF
--- a/src/gtk-3.0/gtk-widgets.css
+++ b/src/gtk-3.0/gtk-widgets.css
@@ -132,19 +132,32 @@ scrollbar.horizontal slider {
 	border-right: 1px solid #8592a7;
 }
 scrollbar.vertical button.up {
-	min-height: 0.5rem;
+	min-height: 0.25rem;
+	border: 0;
+	border-bottom: 1px solid #8592a7;
+	border-radius: 0;
 	-gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
 }
 scrollbar.vertical button.down {
-	min-height: 0.5rem;
+	border: 0;
+	min-height: 0.25rem;
+	border: 0;
+	border-top: 1px solid #8592a7;
+	border-radius: 0;
 	-gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
 }
 scrollbar.horizontal button.up {
-	min-width: 0.5rem;
+	min-width: 0.25rem;
+	border: 0;
+	border-right: 1px solid #8592a7;
+	border-radius: 0;
 	-gtk-icon-source: -gtk-icontheme("pan-start-symbolic");
 }
 scrollbar.horizontal button.down {
-	min-width: 0.5rem;
+	min-width: 0.25rem;
+	border: 0;
+	border-left: 1px solid #8592a7;
+	border-radius: 0;
 	-gtk-icon-source: -gtk-icontheme("pan-end-symbolic");
 }
 


### PR DESCRIPTION
Before and after:

![beforeafter](https://user-images.githubusercontent.com/1471149/118361039-41e03f00-b592-11eb-8fcd-baef9358d6d5.png)

Now the buttons are smaller: more consistent with GTK+ 2 , more space efficient and more consistent with the reset of the theme because not all 4 corners are rounded.