### PR TITLE
Fix small size and missing border in gpicview toolbar buttons

### DIFF
--- a/src/gtk-3.0/gtk-widgets.css
+++ b/src/gtk-3.0/gtk-widgets.css
@@ -64,6 +64,7 @@ rubberband {
 button.flat {
 	background-color: transparent;
 	border: 1px solid transparent;
+	padding: 3px;
 }
 button:not(.flat) , 
 .button {
@@ -82,6 +83,7 @@ button:active:hover, .button:active:hover,
 button.toggle:checked,
 button.toggle:active:hover,
 stackswitcher button:checked {
+	border: 1px solid #8592a7;
 	background-image: linear-gradient(to bottom right, #9fbfe7, #e7effb);
 }
 button:focus, .button:focus {


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/1471149/119610568-1e26bf80-be02-11eb-820e-5b8ca5fc9784.png)

After:
![after](https://user-images.githubusercontent.com/1471149/119610566-1cf59280-be02-11eb-8f62-b8623617847c.png)